### PR TITLE
Trying to get predoc and econ7850 syllabi to show separate dates

### DIFF
--- a/modules/01-introductions-and-motivation.qmd
+++ b/modules/01-introductions-and-motivation.qmd
@@ -11,4 +11,4 @@ opredoc: 1
 - [Introductory slides](presentation/presentation.html)
 - Best practicies, importance of reproducibility, and important habits
 - What is a replication package?
-- A very imperfect [example](presentation/01-very-imperfect-example.html)
+- A very imperfect [example](https://larsvilhuber.github.io/summer-school-qicss-2025/presentation/01-very-imperfect-example.html#/title-slide)

--- a/modules/01-introductions-and-motivation.qmd
+++ b/modules/01-introductions-and-motivation.qmd
@@ -2,7 +2,8 @@
 title: "Introductions and motivation"
 author: Lars Vilhuber
 description: "We introduce the various modules, talk about best practices, describe what we mean by replication package, and illustrate practically using a toy example."
-date: "2025-09-08"
+date-predoc: "2025-08-12"
+date-econ7850: "not sure"
 categories: [predoc]
 opredoc: 1
 ---

--- a/modules/02-useful-tools-command-line.qmd
+++ b/modules/02-useful-tools-command-line.qmd
@@ -1,10 +1,12 @@
 ---
 title: "Useful tools: Why you should learn (and love) the command line"
 author: Lars Vilhuber
-date: "2025-09-15"
+date-econ7850: 2025-09-15
+date-predoc: 2025-08-26
 description: ""
 oecon7850: "2"
 categories: [econ7850, predoc]
+
 ---
 
 - Bash scripting

--- a/modules/03-day1-reproducibility.qmd
+++ b/modules/03-day1-reproducibility.qmd
@@ -1,7 +1,8 @@
 ---
 title: "Day 1 reproducibility"
 author: Lars Vilhuber
-date: "2025-09-22"
+date-econ7850: "2025-09-22"
+date-predoc: "not sure"
 description: "We discuss how to set yourself up for reproducibility from the very first day of your project."
 oecon7850: "1"
 categories: [econ7850, predoc, qicss2025]

--- a/modules/04-day-n-1-reproducibility.qmd
+++ b/modules/04-day-n-1-reproducibility.qmd
@@ -1,7 +1,8 @@
 ---
 title: "Day N-1 reproducibility"
 author: Lars Vilhuber
-date: "2025-09-29"
+date-econ7850: "2025-09-29"
+date-predoc: "2025-10-28"
 description: "How do you check your project for reproducibility before you submit it? We discuss various strategies."
 oecon7850: "5"
 categories: [econ7850, predoc]

--- a/modules/05-confidential-data.qmd
+++ b/modules/05-confidential-data.qmd
@@ -2,7 +2,8 @@
 title: "Working with confidential data, when to share data and when no to"
 author: Lars Vilhuber
 description: "What if you have data you are not allowed to publish? How do you work with it, and how do you share the most of your work? We discuss general and specific methods and strategies."
-date: "2025-10-01"
+date-econ7850: "2025-10-01"
+date-predoc: "not sure"
 categories: [predoc]
 ---
 

--- a/modules/05-confidential-data.qmd
+++ b/modules/05-confidential-data.qmd
@@ -7,5 +7,5 @@ date-predoc: "not sure"
 categories: [predoc]
 ---
 
-- [Reproducibility when data are confidential](https://labordynamicsinstitute.github.io/reproducibility-confidential/#/title-slide)
-- Textbook on reproducibility when data are confidential (in progress)
+- [Reproducibility when data are confidential](https://labordynamicsinstitute.github.io/reproducibility-confidential/presentation/#/title-slide)
+- [Textbook on reproducibility when data are confidential](https://labordynamicsinstitute.github.io/reproducibility-confidential/#/title-slide)

--- a/modules/06-documenting-with-readme.qmd
+++ b/modules/06-documenting-with-readme.qmd
@@ -2,7 +2,8 @@
 title: "Documenting it all with a README"
 author: Lars Vilhuber
 description: "Once you've covered all the bases, how do you document it all? We discuss how to use the template README to document your project. Much of this will recall elements from previous sessions."
-date: "2025-10-06"
+date-econ7850: "2025-10-06"
+date-predoc: "not sure"
 categories: [predoc, qicss2025]
 image: "images/ai-readme.jpeg"
 ---

--- a/modules/07-how-to-run-code-reproducibly.qmd
+++ b/modules/07-how-to-run-code-reproducibly.qmd
@@ -2,7 +2,8 @@
 title: "How to run code reproducibly"
 author: Lars Vilhuber
 description: "This is a recap of the Day N-1 reproducibility module, but with a focus on how to run code reproducibly. We discuss how to create log files, use environments, and the importance of data cleaning."
-date: "2025-10-13"
+date-predoc: "2025-10-13"
+date-econ7859: "not sure"
 categories: [predoc, qicss2025]
 image: "images/ai-careful-scientist.jpeg"
 ---

--- a/modules/08-api-and-ai.qmd
+++ b/modules/08-api-and-ai.qmd
@@ -2,7 +2,8 @@
 title: "API and AI"
 author: Lars Vilhuber
 description: "AI is infusing a lot of what we do. This will discuss how you can produce research that uses AI and APIs, while still being reproducible."
-date: "2025-10-20"
+date-predoc: "2025-10-20"
+date-econ7850: "not sure"
 categories: [predoc]
 ---
 

--- a/modules/09-data-lifecycle-preservation.qmd
+++ b/modules/09-data-lifecycle-preservation.qmd
@@ -2,7 +2,8 @@
 title: "The data lifecycle: preserving raw data"
 author: Lars Vilhuber
 description: "If you create data, or have data that needs to be preserved, what can you do? We start by discussing the distinction between sharing and preserving data, and then look at options that you can embed within your research workflow."
-date: "2025-10-27"
+date-econ7850: "2025-10-27"
+date-predoc: "not sure"
 categories: [econ7850, predoc, qicss2025]
 oecon7850: "9"
 image: "images/2021_06_14_DMPDS.png"

--- a/modules/10-writing-articles-text-code.qmd
+++ b/modules/10-writing-articles-text-code.qmd
@@ -2,7 +2,8 @@
 title: "Writing articles that combine text and code"
 author: Lars Vilhuber
 description: "To more efficiently combine processing of data and the writing up of results, a few methods exist. Word is not one of them. We discuss the pros and cons of various methods."
-date: "2025-11-03"
+date-econ7850: "2025-11-03"
+date-predoc: "not sure"
 categories: [econ7850, predoc]
 oecon7850: "6"
 ---

--- a/modules/11-high-performance-computing.qmd
+++ b/modules/11-high-performance-computing.qmd
@@ -2,7 +2,8 @@
 title: "High-performance computing and why you should care about it"
 author: Lars Vilhuber
 description: "You run your code on your laptop, and it crashes. Use high-performance computing! We disuss when to use it, what the benefits and costs are, and where to use it. "
-date: "2025-11-10"
+date-econ7850: "2025-11-10"
+date-predoc: "not sure"
 categories: [econ7850, predoc]
 oecon7850: "4"
 ---

--- a/modules/12-reproducibility-ethics.qmd
+++ b/modules/12-reproducibility-ethics.qmd
@@ -2,7 +2,8 @@
 title: "Reproducibility, transparency, and data ethics: How and when to share data, and when not to"
 author: Lars Vilhuber
 description: "How do you create transparency and credibility when you cannot share the data you use? We discuss strategies both for data collection, data use, and data sharing. This is relevant if you collect your own data, or if you use confidential data."
-date: "2025-11-10"
+date-econ7850: "2025-11-10"
+date-predoc: "2025-09-09"
 categories: [econ7850, predoc]
 oecon7850: "8"
 ---

--- a/sample-econ7850.qmd
+++ b/sample-econ7850.qmd
@@ -9,12 +9,17 @@ description: "Econ 7850  consists of two parts. In Part 1, we will discuss sever
 essential for successfully completing your research papers as well as applying for grants, refereeing for journals etc. Part 2 are your presentations. In Part 3, after presentations are offered, you will be asked to write a referee report on one of the papers written
 by your peers. You will also be asked to prepare a draft replication package for your own paper."
 listing:
-  contents: 
+  contents:
     - "modules/*.qmd"
     - "extras/*.qmd"
-  type: "table"
+  type: table
   categories: true
-  sort: "oecon7850"
+  fields: [date-econ7850, title, author]
+  field-links: [title]
+  field-display-names:
+    date-predoc: "Date"
+    author: "Authors"
+  sort: "date-econ7850 desc"
   include:
     categories: "econ7850"
 ---

--- a/sample-predoc.qmd
+++ b/sample-predoc.qmd
@@ -1,18 +1,20 @@
 ---
 title: "CIDER Predoc Sequence"
 author: 
- - Lars Vilhuber
- - Laurel Krovetz
-date: "2025-09-01"
+  - Lars Vilhuber
+  - Laurel Krovetz
+date: "2025-08-12"
 description: "TBD"
 listing:
-  contents: 
+  contents:
     - "modules/*.qmd"
     - "extras/*.qmd"
-  type: "table"
-  categories: true
-  sort: "opredoc"
+  type: table
+  fields: [date-predoc, title, author]
+  field-display-names:
+    date-predoc: "Date"
+    author: "Authors"
+  sort: date-predoc desc
   include:
-    categories: "predoc"
----
-
+    categories: predoc
+--- 


### PR DESCRIPTION
Hi Lars,

As per your most recent email, I've been working on trying to get the syllabi to show course specific dates. I think I may have been able to do so by adding to the listing in the header. I've sent a pull request for you to review. I create course specific date fields in each module: "date-econ7850" and "date-predoc" which I can make different from one another, instead of having one "date" field that is the same for both. When I test it out it looks fine, but the links to the pages don't work. I'm not sure if that's an issue on my end or a result of the changes I made. 

Thanks
Laurel

