### PR TITLE
Adding a date field to the modules pages

### DIFF
--- a/modules/01-introductions-and-motivation.qmd
+++ b/modules/01-introductions-and-motivation.qmd
@@ -2,6 +2,7 @@
 title: "Introductions and motivation"
 author: Lars Vilhuber
 description: "We introduce the various modules, talk about best practices, describe what we mean by replication package, and illustrate practically using a toy example."
+date: ""
 date-predoc: "2025-08-25"
 date-econ7850: "2025-08-12"
 categories: [predoc]

--- a/modules/02-useful-tools-command-line.qmd
+++ b/modules/02-useful-tools-command-line.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Useful tools: Why you should learn (and love) the command line"
 author: Lars Vilhuber
+date: ""
 date-econ7850: 2025-09-15
 date-predoc: 2025-08-26
 description: ""

--- a/modules/03-day1-reproducibility.qmd
+++ b/modules/03-day1-reproducibility.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Day 1 reproducibility"
 author: Lars Vilhuber
+date: ""
 date-econ7850: "2025-09-22"
 date-predoc: "2025-09-22"
 description: "We discuss how to set yourself up for reproducibility from the very first day of your project."

--- a/modules/04-day-n-1-reproducibility.qmd
+++ b/modules/04-day-n-1-reproducibility.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Day N-1 reproducibility"
 author: Lars Vilhuber
+date: ""
 date-econ7850: "2025-09-29"
 date-predoc: "2025-10-28"
 description: "How do you check your project for reproducibility before you submit it? We discuss various strategies."

--- a/modules/05-confidential-data.qmd
+++ b/modules/05-confidential-data.qmd
@@ -2,6 +2,7 @@
 title: "Working with confidential data, when to share data and when no to"
 author: Lars Vilhuber
 description: "What if you have data you are not allowed to publish? How do you work with it, and how do you share the most of your work? We discuss general and specific methods and strategies."
+date: ""
 date-econ7850: "2025-10-01"
 date-predoc: "2025-10-01"
 categories: [predoc]

--- a/modules/06-documenting-with-readme.qmd
+++ b/modules/06-documenting-with-readme.qmd
@@ -2,6 +2,7 @@
 title: "Documenting it all with a README"
 author: Lars Vilhuber
 description: "Once you've covered all the bases, how do you document it all? We discuss how to use the template README to document your project. Much of this will recall elements from previous sessions."
+date: ""
 date-econ7850: "2025-10-06"
 date-predoc: "2025-09-07"
 categories: [predoc, qicss2025]

--- a/modules/07-how-to-run-code-reproducibly.qmd
+++ b/modules/07-how-to-run-code-reproducibly.qmd
@@ -2,6 +2,7 @@
 title: "How to run code reproducibly"
 author: Lars Vilhuber
 description: "This is a recap of the Day N-1 reproducibility module, but with a focus on how to run code reproducibly. We discuss how to create log files, use environments, and the importance of data cleaning."
+date: ""
 date-predoc: "2025-10-27"
 date-econ7859: "2025-10-13"
 categories: [predoc, qicss2025]

--- a/modules/08-api-and-ai.qmd
+++ b/modules/08-api-and-ai.qmd
@@ -2,6 +2,7 @@
 title: "API and AI"
 author: Lars Vilhuber
 description: "AI is infusing a lot of what we do. This will discuss how you can produce research that uses AI and APIs, while still being reproducible."
+date: ""
 date-predoc: "2025-10-20"
 date-econ7850: "2025-09-08"
 categories: [predoc]

--- a/modules/09-data-lifecycle-preservation.qmd
+++ b/modules/09-data-lifecycle-preservation.qmd
@@ -2,6 +2,7 @@
 title: "The data lifecycle: preserving raw data"
 author: Lars Vilhuber
 description: "If you create data, or have data that needs to be preserved, what can you do? We start by discussing the distinction between sharing and preserving data, and then look at options that you can embed within your research workflow."
+date: ""
 date-econ7850: "2025-10-27"
 date-predoc: "2025-10-27"
 categories: [econ7850, predoc, qicss2025]

--- a/modules/10-writing-articles-text-code.qmd
+++ b/modules/10-writing-articles-text-code.qmd
@@ -2,6 +2,7 @@
 title: "Writing articles that combine text and code"
 author: Lars Vilhuber
 description: "To more efficiently combine processing of data and the writing up of results, a few methods exist. Word is not one of them. We discuss the pros and cons of various methods."
+date: ""
 date-econ7850: "2025-11-03"
 date-predoc: "2025-9-08"
 categories: [econ7850, predoc]

--- a/modules/11-high-performance-computing.qmd
+++ b/modules/11-high-performance-computing.qmd
@@ -2,6 +2,7 @@
 title: "High-performance computing and why you should care about it"
 author: Lars Vilhuber
 description: "You run your code on your laptop, and it crashes. Use high-performance computing! We disuss when to use it, what the benefits and costs are, and where to use it. "
+date: ""
 date-econ7850: "2025-11-10"
 date-predoc: "2025-9-07"
 categories: [econ7850, predoc]

--- a/modules/12-reproducibility-ethics.qmd
+++ b/modules/12-reproducibility-ethics.qmd
@@ -2,6 +2,7 @@
 title: "Reproducibility, transparency, and data ethics: How and when to share data, and when not to"
 author: Lars Vilhuber
 description: "How do you create transparency and credibility when you cannot share the data you use? We discuss strategies both for data collection, data use, and data sharing. This is relevant if you collect your own data, or if you use confidential data."
+date: ""
 date-econ7850: "2025-11-10"
 date-predoc: "2025-09-09"
 categories: [econ7850, predoc]


### PR DESCRIPTION
Adding a "date" field to the modules pages so that each page can have a published date. This is different from the date that shows up on the syllabi, which are called "date-predoc" and "date-econ7850."